### PR TITLE
Added check for data-src and data-srcset for image

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -598,8 +598,8 @@ extendWithGettersAndSetters(Html.prototype, {
                         }
                     }
                 } else if (nodeName === 'img') {
-                    var srcAttributeValue = node.getAttribute('src'),
-                        srcSetAttributeValue = node.getAttribute('srcset');
+                    var srcAttributeValue = node.getAttribute('src') || node.getAttribute('data-src'),
+                        srcSetAttributeValue = node.getAttribute('srcset') || node.getAttribute('data-srcset');
                     if (srcAttributeValue && this._isRelationUrl(srcAttributeValue)) {
                         addOutgoingRelation(new AssetGraph.HtmlImage({
                             from: this,

--- a/lib/relations/HtmlImage.js
+++ b/lib/relations/HtmlImage.js
@@ -10,11 +10,16 @@ util.inherits(HtmlImage, HtmlRelation);
 
 extendWithGettersAndSetters(HtmlImage.prototype, {
     get href() {
-        return this.node.getAttribute('src');
+        return this.node.hasAttribute("src") ?
+          this.node.getAttribute('src') : this.node.getAttribute('data-src');
     },
 
     set href(href) {
-        this.node.setAttribute('src', href);
+        if (this.node.hasAttribute("src")) {
+            this.node.setAttribute('src', href);
+        } else {
+            this.node.setAttribute('data-src', href);
+        }
     },
 
     attach: function (asset, position, adjacentRelation) {

--- a/lib/relations/HtmlImageSrcSet.js
+++ b/lib/relations/HtmlImageSrcSet.js
@@ -12,6 +12,12 @@ util.inherits(HtmlImageSrcSet, HtmlRelation);
 extendWithGettersAndSetters(HtmlImageSrcSet.prototype, {
     inline: function () {
         Relation.prototype.inline.call(this);
+        if (this.node.hasAttribute('srcset')) {
+            this.node.setAttribute('srcset', this.to.text);
+        } else {
+            this.node.setAttribute('data-srcset', this.to.text);
+        }
+
         this.node.setAttribute('srcset', this.to.text);
         this.from.markDirty();
         return this;


### PR DESCRIPTION
    If data-src is used instead of src then apply transformation as per  that attribute.
    If data-srcset is used instead of srcset then apply transformation as per that attribute.

    If Both are present src and data-src then we will transform src and will update only src attribute.
    If Both are present srcset and data-srcset then we will transform srcset and will update only srcset attribute.